### PR TITLE
Update ClusterAndInfrastructureSpecifications.adoc

### DIFF
--- a/modules/ClusterAndInfrastructureSpecifications.adoc
+++ b/modules/ClusterAndInfrastructureSpecifications.adoc
@@ -105,7 +105,7 @@ The following roles are responsible for implementation:
 
 You must address this topic before onboarding production workloads.
 
-== Concept (e.g. Carrying Technical Information)
+== Production Cluster: Specifications
 
 You will need to do the following:
 


### PR DESCRIPTION
Updated the Concepts headline so it reflected the concept rather than the template "carrying technical information"